### PR TITLE
Specify which class to use

### DIFF
--- a/Java-Armstrong/Armstrong.java
+++ b/Java-Armstrong/Armstrong.java
@@ -1,4 +1,4 @@
-import java.util.*;
+import java.util.Scanner;
 
 public class Armstrong{
 	


### PR DESCRIPTION
Specify `java.util.Scanner` instead of importing all the classes from `java.util` package.
